### PR TITLE
AWN-68514 - GitHub Advanced Security Automation[bot]

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,50 @@
+################
+# DO NOT EDIT! #
+################
+# This file is maintained by https://github.com/rtkwlf/devsecops-gh-automation
+# making any changes here will prompt a new PR to
+# be opened against your repository.
+# Please reach out to Cloud Security Group with questions, comments, or issues.
+# https://arcticwolf.atlassian.net/wiki/spaces/AWD/pages/2912944394/Engaging+the+DevSecOps+team
+version: 2
+# Define the registry for the rtkwlf-actions GitHub Org
+registries:
+  github-rtkwlf-actions:
+    type: git
+    url: https://github.com
+    username: rtkdependabot
+    password: ${{ secrets.RTKWLF_ACTIONS_PAT }}
+
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    labels:
+      - dependencies
+      - github-actions
+      - patch release
+    registries:
+      - github-rtkwlf-actions
+  # Maintain dependencies for docker
+  - package-ecosystem: docker
+    directory: .
+    schedule:
+      interval: weekly
+      day: sunday
+    labels:
+      - dependencies
+      - docker
+      - patch release
+  # Maintain dependencies for npm
+  - package-ecosystem: npm
+    directory: .
+    schedule:
+      interval: weekly
+      day: sunday
+    labels:
+      - dependencies
+      - npm
+      - patch release

--- a/.github/workflows/close-merged-dependabot-ticket.yaml
+++ b/.github/workflows/close-merged-dependabot-ticket.yaml
@@ -1,0 +1,24 @@
+################
+# DO NOT EDIT! #
+################
+# This file is maintained by Cloud Security Group automation,
+# making any changes here will prompt a new PR to
+# be opened against your repository.
+# Please reach out to Cloud Security Group if there are any questions, concerns, or to report any errors.
+# https://arcticwolf.atlassian.net/wiki/spaces/AWD/pages/2912944394/Engaging+the+DevSecOps+team
+name: close-merged-dependabot-ticket
+on:
+  pull_request:
+    types:
+      - closed
+jobs:
+  close-jira-ticket:
+    if: github.event.pull_request.merged == true && github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Close dependabot ticket
+        uses: rtkwlf-actions/close-dependabot-ticket@v1
+        with:
+          jira_api_token: ${{ secrets.PAT_RTKWLF_DEVSECOPS_TICKETER }}
+          jira_user: ${{ secrets.RTKWLF_DEVSECOPS_TICKETER_EMAIL }}
+          pr_title: ${{ github.event.pull_request.title }}

--- a/.github/workflows/dependabot-ticketer.yaml
+++ b/.github/workflows/dependabot-ticketer.yaml
@@ -1,0 +1,88 @@
+################
+# DO NOT EDIT! #
+################
+# This file is maintained by Cloud Security Group automation,
+# making any changes here will prompt a new PR to
+# be opened against your repository.
+# Please reach out to Cloud Security Group if there are any questions, concerns, or to report any errors.
+# https://arcticwolf.atlassian.net/wiki/spaces/AWD/pages/2912944394/Engaging+the+DevSecOps+team
+name: dependabot workflow
+on:
+  pull_request:
+    types:
+      - opened
+
+permissions:
+  pull-requests: write
+  issues: write
+  repository-projects: write
+
+jobs:
+  dependabot-ticketer:
+    runs-on: ubuntu-20.04
+    if: github.actor == 'dependabot[bot]'
+    env:
+      JIRA_API_TOKEN: ${{ secrets.PAT_RTKWLF_DEVSECOPS_TICKETER }}
+      JIRA_BASE_URL: ${{ secrets.RTKWLF_JIRA_BASE_URL }}
+      JIRA_ISSUE_TYPE: R&D Security Finding
+      JIRA_PROJECT: AWN
+      JIRA_RND_TEAM: ''
+      JIRA_USER_EMAIL: ${{ secrets.RTKWLF_DEVSECOPS_TICKETER_EMAIL }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get Dependabots Original PR Title
+        id: dependabot-title
+        run: echo "DBOT_TITLE=$(gh pr view --json title "$PR_URL" -q .title)" >> "$GITHUB_OUTPUT"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: login to jira
+        uses: atlassian/gajira-login@v3
+        env:
+          JIRA_API_TOKEN: ${{ env.JIRA_API_TOKEN }}
+          JIRA_BASE_URL: ${{ env.JIRA_BASE_URL }}
+          JIRA_USER_EMAIL: ${{ env.JIRA_USER_EMAIL }}
+
+      - name: create jira issue
+        id: create
+        uses: atlassian/gajira-create@v3
+        with:
+          project: ${{ env.JIRA_PROJECT }}
+          issuetype: ${{ env.JIRA_ISSUE_TYPE }}
+          summary: |
+            [Dependabot] - ${{ github.event.repository.name }} - ${{ steps.dependabot-title.outputs.DBOT_TITLE }}
+          description: |
+            GitHub PR: ${{ github.event.repository.html_url }}/pull/${{ github.event.pull_request.number }}
+            Package Type: ${{ steps.metadata.outputs.package-ecosystem }}
+          # The gajira-create module explicity uses json in the YAML configuration
+          fields: |
+            {
+                "customfield_10700": {
+                    "value": "${{ env.JIRA_RND_TEAM }}"
+                },
+                "customfield_12980": "Dependabot",
+                "labels": [
+                    "source:dbot_ticketer",
+                    "pkgman:${{ steps.metadata.outputs.package-ecosystem }}",
+                    "org:${{ github.repository_owner }}"
+                ],
+                "customfield_14651": 0.008
+            }
+
+      - name: Add Jira ticket URL to PR
+        run: gh pr edit "$PR_URL" --title "${{ steps.create.outputs.issue }} - ${{ steps.dependabot-title.outputs.DBOT_TITLE }}"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Add patch release label
+        run: gh pr edit "$PR_URL" --add-label "patch release"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Why am I getting this PR?
This PR was opened by the devsecops-gh-automation repository. The automation from this repository will run
once every 24 hours, to ensure repositories are staying up-to-date, removing the need for developers to
have to maintain their GitHub Advanced Security configurations. For more information, please read our 
[DORY](https://arcticwolf.atlassian.net/wiki/spaces/PD/pages/2912649537/GitHub+Advanced+Security+GHAS+and+Dory+Cyclops) documentation.

## Action Items

- [ ] Ensure [Jira R&D Team](.github/workflows/dependabot-ticketer.yaml?plain=1#32) is filled out (only necessary on first PR or when updating the team receiving tickets)
- [ ] Review PR to confirm it's accuracy


### CHANGES ( Message #rnd_devsecops if you have any questions )
- Enabled the ability to customize the dependabot job. (https://arcticwolf.atlassian.net/wiki/spaces/PD/pages/3639383282/2023-08-03+-+DaveCyclops+Says...+-+Support+For+Dependabot+Dependency+Groups)
