### PR TITLE
AWN-1013554: Add the upload-coverage job to the CI workflow

### DIFF
--- a/.github/workflows/scans_ci.yml
+++ b/.github/workflows/scans_ci.yml
@@ -1,4 +1,4 @@
-name: 
+name:
 on: [push, pull_request, create, delete, issue_comment]
 
 jobs:
@@ -23,3 +23,18 @@ jobs:
 
       - name: NPM Test
         run: npm test
+      - name: Upload Coverage Reports to GitHub
+        id: upload-coverage-github
+        uses: actions/upload-artifact@v4
+        with:
+          path: bazel-out/_coverage
+          name: "coverage"
+  upload-coverage-to-backstage:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build
+    permissions:
+      id-token: write
+    uses: rtkwlf-actions/common-build/.github/workflows/code-coverage-upload.yaml@v8
+    with:
+      artifact-name: "coverage"
+      component-name: "${{ github.repository_owner }}-${{ github.event.repository.name }}"


### PR DESCRIPTION
## Summary
In an effort to improve visibility into code quality, the CI team has created a Github workflow that uploads code coverage into Backstage. This PR adds the job necessary to upload your code coverage to Backstage. If there is no coverage currently being generated, this step will upload an empty coverage report.

We've created documentation to help you generate code coverage and integrate with the job we've added to your
CI workflow. Take a look at the following [doc](https://arcticwolf.atlassian.net/wiki/spaces/PD/pages/4154327912/How+do+I+get+my+code+coverage+report+uploaded+to+Backstage) to quickly start uploading code coverage reports.

*Questions?*
Please reach out to the CI team in `#rnd_ci` or `#rnd_buildsupport` and we will be happy to provide more information
or guidance.
## Release Notes
Add the `upload-coverage` job to the CI workflow.
